### PR TITLE
Mimic original osu! exit button

### DIFF
--- a/src/itdelatrisu/opsu/states/Options.java
+++ b/src/itdelatrisu/opsu/states/Options.java
@@ -306,7 +306,7 @@ public class Options extends BasicGameState {
 	/**
 	 * Offset time, in milliseconds, for music position-related elements.
 	 */
-	private static int musicOffset = 0;
+	private static int musicOffset = -150;
 
 	/**
 	 * Screenshot file format.


### PR DESCRIPTION
The osu! exit button (original client) exits the game. Pressing ESC brings up the exit menu.

Uhh. I originally proposed a pull request to make the default offset 0, but I guess nevermind.
