### PR TITLE
close mp3 file handles.

### DIFF
--- a/src/org/newdawn/slick/openal/Mp3InputStream.java
+++ b/src/org/newdawn/slick/openal/Mp3InputStream.java
@@ -199,4 +199,13 @@ public class Mp3InputStream extends InputStream implements AudioInputStream {
 
 		return skipped;
 	}
+
+	@Override
+	public void close() throws IOException {
+		try {
+			bitstream.close();
+		} catch (BitstreamException e) {
+			e.printStackTrace();
+		}
+	}
 }

--- a/src/org/newdawn/slick/openal/OpenALStreamPlayer.java
+++ b/src/org/newdawn/slick/openal/OpenALStreamPlayer.java
@@ -392,5 +392,16 @@ public class OpenALStreamPlayer {
 	public void resuming() {
 		lastUpdateTime = System.currentTimeMillis() - offsetTime;
 	}
+
+	public void close() {
+		if(audio != null){
+			try {
+				audio.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
+		
+	}
 }
 

--- a/src/org/newdawn/slick/openal/SoundStore.java
+++ b/src/org/newdawn/slick/openal/SoundStore.java
@@ -916,6 +916,9 @@ public class SoundStore {
 			return;
 		}
 
+		if(this.stream != null){
+			this.stream.close();
+		}
 		currentMusic = sources.get(0);
 		this.stream = stream;
 		if (stream != null) {


### PR DESCRIPTION
Close file handles so files can be deleted.

Not sure if this fixed the memory leak.