### PR TITLE
Remove restriction from left/right click keys

### DIFF
--- a/src/itdelatrisu/opsu/Options.java
+++ b/src/itdelatrisu/opsu/Options.java
@@ -713,7 +713,7 @@ public class Options {
 	 */
 	public static int getGameKeyLeft() {
 		if (keyLeft == Keyboard.KEY_NONE)
-			keyLeft = Input.KEY_Z;
+			setGameKeyLeft(Input.KEY_Z);
 		return keyLeft;
 	}
 
@@ -723,21 +723,39 @@ public class Options {
 	 */
 	public static int getGameKeyRight() {
 		if (keyRight == Keyboard.KEY_NONE)
-			keyRight = Input.KEY_X;
+			setGameKeyRight(Input.KEY_X);
 		return keyRight;
 	}
 
 	/**
 	 * Sets the left game key.
+	 * This will not be set to the same key as the right game key, nor to reserved keys like ESCAPE.
 	 * @param key the keyboard key
+	 * @return {@code true} if the key was set, {@code false} if it was rejected
 	 */
-	public static void setGameKeyLeft(int key) { keyLeft = key; }
+	public static boolean setGameKeyLeft(int key) {
+		if (key == keyRight && key != Keyboard.KEY_NONE)
+			return false;
+		if (!isValidClickKey(key))
+			return false;
+		keyLeft = key;
+		return true;
+	}
 
 	/**
 	 * Sets the right game key.
+	 * This will not be set to the same key as the left game key, nor to reserved keys like ESCAPE.
 	 * @param key the keyboard key
+	 * @return {@code true} if the key was set, {@code false} if it was rejected
 	 */
-	public static void setGameKeyRight(int key) { keyRight = key; }
+	public static boolean setGameKeyRight(int key) {
+		if (key == keyLeft && key != Keyboard.KEY_NONE)
+			return false;
+		if (!isValidClickKey(key))
+			return false;
+		keyRight = key;
+		return true;
+	}
 
 	/**
 	 * Returns the beatmap directory.
@@ -823,6 +841,10 @@ public class Options {
 		}
 
 		return osu;
+	}
+
+	public static boolean isValidClickKey(int keyCode) {
+		return keyCode != Keyboard.KEY_ESCAPE;
 	}
 
 	/**
@@ -935,14 +957,10 @@ public class Options {
 						GameOption.DISABLE_SOUNDS.setValue(Boolean.parseBoolean(value));
 						break;
 					case "keyOsuLeft":
-						i = Keyboard.getKeyIndex(value);
-						if (keyRight != i)
-							keyLeft = i;
+						setGameKeyLeft(Keyboard.getKeyIndex(value));
 						break;
 					case "keyOsuRight":
-						i = Keyboard.getKeyIndex(value);
-						if (keyLeft != i)
-							keyRight = i;
+						setGameKeyRight(Keyboard.getKeyIndex(value));
 						break;
 					case "MouseDisableWheel":
 						GameOption.DISABLE_MOUSE_WHEEL.setValue(Boolean.parseBoolean(value));

--- a/src/itdelatrisu/opsu/Options.java
+++ b/src/itdelatrisu/opsu/Options.java
@@ -935,20 +935,14 @@ public class Options {
 						GameOption.DISABLE_SOUNDS.setValue(Boolean.parseBoolean(value));
 						break;
 					case "keyOsuLeft":
-						if ((value.length() == 1 && Character.isLetterOrDigit(value.charAt(0))) ||
-							(value.length() == 7 && value.startsWith("NUMPAD"))) {
-							i = Keyboard.getKeyIndex(value);
-							if (keyRight != i)
-								keyLeft = i;
-						}
+						i = Keyboard.getKeyIndex(value);
+						if (keyRight != i)
+							keyLeft = i;
 						break;
 					case "keyOsuRight":
-						if ((value.length() == 1 && Character.isLetterOrDigit(value.charAt(0))) ||
-							(value.length() == 7 && value.startsWith("NUMPAD"))) {
-							i = Keyboard.getKeyIndex(value);
-							if (keyLeft != i)
-								keyRight = i;
-						}
+						i = Keyboard.getKeyIndex(value);
+						if (keyLeft != i)
+							keyRight = i;
 						break;
 					case "MouseDisableWheel":
 						GameOption.DISABLE_MOUSE_WHEEL.setValue(Boolean.parseBoolean(value));

--- a/src/itdelatrisu/opsu/states/OptionsMenu.java
+++ b/src/itdelatrisu/opsu/states/OptionsMenu.java
@@ -347,9 +347,9 @@ public class OptionsMenu extends BasicGameState {
 	public void keyPressed(int key, char c) {
 		// key entry state
 		if (keyEntryLeft || keyEntryRight) {
-			if (keyEntryLeft && Options.getGameKeyRight() != key)
+			if (keyEntryLeft)
 				Options.setGameKeyLeft(key);
-			else if (keyEntryRight && Options.getGameKeyLeft() != key)
+			else
 				Options.setGameKeyRight(key);
 			keyEntryLeft = keyEntryRight = false;
 			return;

--- a/src/itdelatrisu/opsu/states/OptionsMenu.java
+++ b/src/itdelatrisu/opsu/states/OptionsMenu.java
@@ -243,9 +243,17 @@ public class OptionsMenu extends BasicGameState {
 			g.setColor(Utils.COLOR_BLACK_ALPHA);
 			g.fillRect(0, 0, width, height);
 			g.setColor(Color.white);
+
+			String prompt;
+			if (keyEntryLeft) {
+				prompt = "Please press the new left-click key";
+			} else {
+				prompt = "Please press the new right-click key";
+			}
+
 			Utils.FONT_LARGE.drawString(
-					(width / 2) - (Utils.FONT_LARGE.getWidth("Please enter a letter or digit.") / 2),
-					(height / 2) - Utils.FONT_LARGE.getLineHeight(), "Please enter a letter or digit."
+					(width / 2) - (Utils.FONT_LARGE.getWidth(prompt) / 2),
+					(height / 2) - Utils.FONT_LARGE.getLineHeight(), prompt
 			);
 		}
 
@@ -339,12 +347,10 @@ public class OptionsMenu extends BasicGameState {
 	public void keyPressed(int key, char c) {
 		// key entry state
 		if (keyEntryLeft || keyEntryRight) {
-			if (Character.isLetterOrDigit(c)) {
-				if (keyEntryLeft && Options.getGameKeyRight() != key)
-					Options.setGameKeyLeft(key);
-				else if (keyEntryRight && Options.getGameKeyLeft() != key)
-					Options.setGameKeyRight(key);
-			}
+			if (keyEntryLeft && Options.getGameKeyRight() != key)
+				Options.setGameKeyLeft(key);
+			else if (keyEntryRight && Options.getGameKeyLeft() != key)
+				Options.setGameKeyRight(key);
 			keyEntryLeft = keyEntryRight = false;
 			return;
 		}


### PR DESCRIPTION
I use the comma and period keys to click with. Since I have the tablet directly in front of my keyboard, that stops me from having to reach all the way over to the z/x keys which would be quite uncomfortable.

There's no reason why someone can't have ctrl/alt or home/pgup as their preferred keys either. At the moment I think just escape needs to be checked for to make this "idiot proof", but I would question the usefulness of idiot-proofing to that degree. I've done it anyway.