### PR TITLE
Hit object stacking algorithm

### DIFF
--- a/src/itdelatrisu/opsu/OsuHitObject.java
+++ b/src/itdelatrisu/opsu/OsuHitObject.java
@@ -72,8 +72,26 @@ public class OsuHitObject {
 	/** The container height. */
 	private static int containerHeight;
 
+	/**
+	 * Return stack position modifier in pixels.
+	 * @return stack position modifier.
+	 */
+	public static float getStackOffset() { return stackOffset; }
+
+	/**
+	 * Sets stack position modifier in pixels
+	 * @param offset position modifier.
+	 */
+	public static void setStackOffset(float offset) { stackOffset = offset; }
+
+	/** The offset per stack. */
+	private static float stackOffset;
+
 	/** Starting coordinates. */
 	private float x, y;
+
+	/** Hit object index in current stack. */
+	private int stack;
 
 	/** Start time (in ms). */
 	private int time;
@@ -249,17 +267,29 @@ public class OsuHitObject {
 	/**
 	 * Returns the scaled starting x coordinate.
 	 */
-	public float getScaledX() { return x * xMultiplier + xOffset; }
+	public float getScaledX() { return (x - stack * stackOffset) * xMultiplier + xOffset; }
 
 	/**
 	 * Returns the scaled starting y coordinate.
 	 */
 	public float getScaledY() {
 		if (GameMod.HARD_ROCK.isActive())
-			return containerHeight - (y * yMultiplier + yOffset);
+			return containerHeight - ((y - stack * stackOffset) * yMultiplier + yOffset);
 		else
-			return y * yMultiplier + yOffset;
+			return (y - stack * stackOffset) * yMultiplier + yOffset;
 	}
+
+	/**
+	 * Sets the hit object index in current stack.
+	 * @param stack index in stack
+	 */
+	public void setStack(int stack) { this.stack = stack; }
+
+	/**
+	 * Returns hit object index in current stack.
+	 * @return index in stack
+	 */
+	public int getStack() { return stack; }
 
 	/**
 	 * Returns the start time.
@@ -331,7 +361,7 @@ public class OsuHitObject {
 
 		float[] x = new float[sliderX.length];
 		for (int i = 0; i < x.length; i++)
-			x[i] = sliderX[i] * xMultiplier + xOffset;
+			x[i] = (sliderX[i] - stack * stackOffset) * xMultiplier + xOffset;
 		return x;
 	}
 
@@ -346,10 +376,10 @@ public class OsuHitObject {
 		float[] y = new float[sliderY.length];
 		if (GameMod.HARD_ROCK.isActive()) {
 			for (int i = 0; i < y.length; i++)
-				y[i] = containerHeight - (sliderY[i] * yMultiplier + yOffset);
+				y[i] = containerHeight - ((sliderY[i] - stack * stackOffset) * yMultiplier + yOffset);
 		} else {
 			for (int i = 0; i < y.length; i++)
-				y[i] = sliderY[i] * yMultiplier + yOffset;
+				y[i] = (sliderY[i] - stack * stackOffset) * yMultiplier + yOffset;
 		}
 		return y;
 	}

--- a/src/itdelatrisu/opsu/Utils.java
+++ b/src/itdelatrisu/opsu/Utils.java
@@ -251,6 +251,20 @@ public class Utils {
 	}
 
 	/**
+	 *
+	 * @param x1 The x-component of the first point
+	 * @param y1 The y-component of the first point
+	 * @param x2 The x-component of the second point
+	 * @param y2 The y-component of the second point
+	 * @return Euclidean distance between points (x1,y1) and (x2,y2)
+	 */
+	public static float distance(float x1, float y1, float x2, float y2) {
+		float v1 = Math.abs(x1 - x2);
+		float v2 = Math.abs(y1 - y2);
+		return (float) Math.sqrt((v1 * v1) + (v2 * v2));
+	}
+
+	/**
 	 * Returns true if a game input key is pressed (mouse/keyboard left/right).
 	 * @return true if pressed
 	 */

--- a/src/itdelatrisu/opsu/objects/Circle.java
+++ b/src/itdelatrisu/opsu/objects/Circle.java
@@ -185,9 +185,6 @@ public class Circle implements HitObject {
 	public int getEndTime() { return hitObject.getTime(); }
 
 	@Override
-	public OsuHitObject getHitObject() { return hitObject; }
-
-	@Override
 	public void updatePosition() {
 		this.x = hitObject.getScaledX();
 		this.y = hitObject.getScaledY();

--- a/src/itdelatrisu/opsu/objects/Circle.java
+++ b/src/itdelatrisu/opsu/objects/Circle.java
@@ -183,4 +183,13 @@ public class Circle implements HitObject {
 
 	@Override
 	public int getEndTime() { return hitObject.getTime(); }
+
+	@Override
+	public OsuHitObject getHitObject() { return hitObject; }
+
+	@Override
+	public void updatePosition() {
+		this.x = hitObject.getScaledX();
+		this.y = hitObject.getScaledY();
+	}
 }

--- a/src/itdelatrisu/opsu/objects/DummyObject.java
+++ b/src/itdelatrisu/opsu/objects/DummyObject.java
@@ -54,6 +54,15 @@ public class DummyObject implements HitObject {
 	public boolean mousePressed(int x, int y, int trackPosition) { return false; }
 
 	@Override
+	public OsuHitObject getHitObject() { return hitObject; }
+
+	@Override
+	public void updatePosition() {
+		this.x = hitObject.getScaledX();
+		this.y = hitObject.getScaledY();
+	}
+
+	@Override
 	public float[] getPointAt(int trackPosition) { return new float[] { x, y }; }
 
 	@Override

--- a/src/itdelatrisu/opsu/objects/DummyObject.java
+++ b/src/itdelatrisu/opsu/objects/DummyObject.java
@@ -54,9 +54,6 @@ public class DummyObject implements HitObject {
 	public boolean mousePressed(int x, int y, int trackPosition) { return false; }
 
 	@Override
-	public OsuHitObject getHitObject() { return hitObject; }
-
-	@Override
 	public void updatePosition() {
 		this.x = hitObject.getScaledX();
 		this.y = hitObject.getScaledY();

--- a/src/itdelatrisu/opsu/objects/HitObject.java
+++ b/src/itdelatrisu/opsu/objects/HitObject.java
@@ -18,6 +18,7 @@
 
 package itdelatrisu.opsu.objects;
 
+import itdelatrisu.opsu.OsuHitObject;
 import org.newdawn.slick.Graphics;
 
 /**
@@ -64,4 +65,15 @@ public interface HitObject {
 	 * @return the end time, in milliseconds
 	 */
 	public int getEndTime();
+
+	/**
+	 * Return associated OsuHitObject.
+	 * @return hit object as OsuHitObject
+	 */
+	public OsuHitObject getHitObject();
+
+	/**
+	 * Updates position of hit object.
+	 */
+	public void updatePosition();
 }

--- a/src/itdelatrisu/opsu/objects/HitObject.java
+++ b/src/itdelatrisu/opsu/objects/HitObject.java
@@ -67,12 +67,6 @@ public interface HitObject {
 	public int getEndTime();
 
 	/**
-	 * Return associated OsuHitObject.
-	 * @return hit object as OsuHitObject
-	 */
-	public OsuHitObject getHitObject();
-
-	/**
 	 * Updates position of hit object.
 	 */
 	public void updatePosition();

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -452,9 +452,6 @@ public class Slider implements HitObject {
 	}
 
 	@Override
-	public OsuHitObject getHitObject() { return hitObject; }
-
-	@Override
 	public void updatePosition() {
 		this.x = hitObject.getScaledX();
 		this.y = hitObject.getScaledY();

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -455,6 +455,11 @@ public class Slider implements HitObject {
 	public void updatePosition() {
 		this.x = hitObject.getScaledX();
 		this.y = hitObject.getScaledY();
+
+		if (hitObject.getSliderType() == OsuHitObject.SLIDER_PASSTHROUGH && hitObject.getSliderX().length == 2)
+			this.curve = new CircumscribedCircle(hitObject, color);
+		else
+			this.curve = new LinearBezier(hitObject, color);
 	}
 
 	@Override

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -455,11 +455,6 @@ public class Slider implements HitObject {
 	public void updatePosition() {
 		this.x = hitObject.getScaledX();
 		this.y = hitObject.getScaledY();
-
-		if (hitObject.getSliderType() == OsuHitObject.SLIDER_PASSTHROUGH && hitObject.getSliderX().length == 2)
-			this.curve = new CircumscribedCircle(hitObject, color);
-		else
-			this.curve = new LinearBezier(hitObject, color);
 	}
 
 	@Override

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -146,6 +146,21 @@ public class Slider implements HitObject {
 			this.curve = new CircumscribedCircle(hitObject, color);
 		else
 			this.curve = new LinearBezier(hitObject, color);
+
+		// slider time calculations
+		this.sliderTime = game.getBeatLength() * (hitObject.getPixelLength() / sliderMultiplier) / 100f;
+		this.sliderTimeTotal = sliderTime * hitObject.getRepeatCount();
+
+		// ticks
+		float tickLengthDiv = 100f * sliderMultiplier / sliderTickRate / game.getTimingPointMultiplier();
+		int tickCount = (int) Math.ceil(hitObject.getPixelLength() / tickLengthDiv) - 1;
+		if (tickCount > 0) {
+			this.ticksT = new float[tickCount];
+			float tickTOffset = 1f / (tickCount + 1);
+			float t = tickTOffset;
+			for (int i = 0; i < tickCount; i++, t += tickTOffset)
+				ticksT[i] = t;
+		}
 	}
 
 	@Override
@@ -313,25 +328,6 @@ public class Slider implements HitObject {
 	@Override
 	public boolean update(boolean overlap, int delta, int mouseX, int mouseY, boolean keyPressed, int trackPosition) {
 		int repeatCount = hitObject.getRepeatCount();
-
-		// slider time and tick calculations
-		if (sliderTimeTotal == 0f) {
-			// slider time
-			this.sliderTime = game.getBeatLength() * (hitObject.getPixelLength() / sliderMultiplier) / 100f;
-			this.sliderTimeTotal = sliderTime * repeatCount;
-
-			// ticks
-			float tickLengthDiv = 100f * sliderMultiplier / sliderTickRate / game.getTimingPointMultiplier();
-			int tickCount = (int) Math.ceil(hitObject.getPixelLength() / tickLengthDiv) - 1;
-			if (tickCount > 0) {
-				this.ticksT = new float[tickCount];
-				float tickTOffset = 1f / (tickCount + 1);
-				float t = tickTOffset;
-				for (int i = 0; i < tickCount; i++, t += tickTOffset)
-					ticksT[i] = t;
-			}
-		}
-
 		int[] hitResultOffset = game.getHitResultOffsets();
 		boolean isAutoMod = GameMod.AUTO.isActive();
 
@@ -453,6 +449,20 @@ public class Slider implements HitObject {
 		}
 
 		return false;
+	}
+
+	@Override
+	public OsuHitObject getHitObject() { return hitObject; }
+
+	@Override
+	public void updatePosition() {
+		this.x = hitObject.getScaledX();
+		this.y = hitObject.getScaledY();
+
+		if (hitObject.getSliderType() == OsuHitObject.SLIDER_PASSTHROUGH && hitObject.getSliderX().length == 2)
+			this.curve = new CircumscribedCircle(hitObject, color);
+		else
+			this.curve = new LinearBezier(hitObject, color);
 	}
 
 	@Override

--- a/src/itdelatrisu/opsu/objects/Spinner.java
+++ b/src/itdelatrisu/opsu/objects/Spinner.java
@@ -264,9 +264,6 @@ public class Spinner implements HitObject {
 	}
 
 	@Override
-	public OsuHitObject getHitObject() { return hitObject; }
-
-	@Override
 	public void updatePosition() {}
 
 	@Override

--- a/src/itdelatrisu/opsu/objects/Spinner.java
+++ b/src/itdelatrisu/opsu/objects/Spinner.java
@@ -264,6 +264,12 @@ public class Spinner implements HitObject {
 	}
 
 	@Override
+	public OsuHitObject getHitObject() { return hitObject; }
+
+	@Override
+	public void updatePosition() {}
+
+	@Override
 	public float[] getPointAt(int trackPosition) {
 		// get spinner time
 		int timeDiff;

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -92,6 +92,9 @@ public class Game extends BasicGameState {
 	/** Stack time window of the previous object in ms. */
 	private static final int STACK_TIMEOUT = 1000;
 
+	/** Stack position offset modifier. */
+	private static final float STACK_OFFSET_MODIFIER = 0.05f;
+
 	/** The associated OsuFile object. */
 	private OsuFile osu;
 
@@ -1109,12 +1112,9 @@ public class Game extends BasicGameState {
 						}
 					}
 					// not a special case. stack moves up left
-					float x1 = hitObjectI.getX();
-					float y1 = hitObjectI.getY();
-					float x2 = hitObjectN.getX();
-					float y2 = hitObjectN.getY();
-					float distance = Utils.distance(x1, y1, x2, y2);
-					if (distance < STACK_LENIENCE * OsuHitObject.getXMultiplier()) {
+					float distance = Utils.distance(hitObjectI.getX(), hitObjectI.getY(),
+							hitObjectN.getX(), hitObjectN.getY());
+					if (distance < STACK_LENIENCE) {
 						hitObjectN.setStack(hitObjectI.getStack() + 1);
 						hitObjectI = hitObjectN;
 					}
@@ -1123,7 +1123,9 @@ public class Game extends BasicGameState {
 
 			// update hit objects positions
 			for (int i = 0; i < hitObjects.length; i++) {
-				hitObjects[i].updatePosition();
+				if(osu.objects[i].getStack() != 0) {
+					hitObjects[i].updatePosition();
+				}
 			}
 
 			// load the first timingPoint
@@ -1415,8 +1417,9 @@ public class Game extends BasicGameState {
 			HPDrainRate = Options.getFixedHP();
 
 		// Stack modifier scales with hit object size
+		// StackOffset = HitObjectRadius / 10
 		int diameter = (int) (104 - (circleSize * 8));
-		OsuHitObject.setStackOffset(diameter * 0.05f);
+		OsuHitObject.setStackOffset(diameter * STACK_OFFSET_MODIFIER);
 
 		// initialize objects
 		Circle.init(container, circleSize);

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -1066,7 +1066,7 @@ public class Game extends BasicGameState {
 
 			// stack calculation
 			for (int i = hitObjects.length - 1; i > 0; i--) {
-				OsuHitObject hitObjectI = hitObjects[i].getHitObject();
+				OsuHitObject hitObjectI = osu.objects[i];
 
 				// already calculated
 				if (hitObjectI.getStack() != 0 || hitObjectI.isSpinner())
@@ -1074,7 +1074,7 @@ public class Game extends BasicGameState {
 
 				// search for hit objects in stack
 				for (int n = i -1; n >= 0; n--) {
-					OsuHitObject hitObjectN = hitObjects[n].getHitObject();
+					OsuHitObject hitObjectN = osu.objects[n];
 
 					if (hitObjectN.isSpinner())
 						continue;
@@ -1098,7 +1098,7 @@ public class Game extends BasicGameState {
 						if (distance < STACK_LENIENCE * OsuHitObject.getXMultiplier()) {
 							int offset = hitObjectI.getStack() - hitObjectN.getStack() + 1;
 							for (int j = n + 1; j <= i; j++) {
-								OsuHitObject hitObjectJ = hitObjects[j].getHitObject();
+								OsuHitObject hitObjectJ = osu.objects[j];
 								x1 = hitObjects[j].getPointAt(hitObjectJ.getTime())[0];
 								y1 = hitObjects[j].getPointAt(hitObjectJ.getTime())[1];
 								distance = Utils.distance(x1, y1, x2, y2);

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -666,10 +666,7 @@ public class Game extends BasicGameState {
 		if (timingPointIndex < osu.timingPoints.size()) {
 			OsuTimingPoint timingPoint = osu.timingPoints.get(timingPointIndex);
 			if (trackPosition >= timingPoint.getTime()) {
-				if (!timingPoint.isInherited())
-					beatLengthBase = beatLength = timingPoint.getBeatLength();
-				else
-					beatLength = beatLengthBase * timingPoint.getSliderMultiplier();
+				setBeatLength(timingPoint);
 				HitSound.setDefaultSampleSet(timingPoint.getSampleType());
 				SoundController.setSampleVolume(timingPoint.getSampleVolume());
 				timingPointIndex++;
@@ -1039,10 +1036,7 @@ public class Game extends BasicGameState {
 				while (timingPointIndex < osu.timingPoints.size()) {
 					OsuTimingPoint timingPoint = osu.timingPoints.get(timingPointIndex);
 					if (timingPoint.getTime() <= hitObjectTime) {
-						if (!timingPoint.isInherited())
-							beatLengthBase = beatLength = timingPoint.getBeatLength();
-						else
-							beatLength = beatLengthBase * timingPoint.getSliderMultiplier();
+						setBeatLength(timingPoint);
 					} else
 						break;
 					timingPointIndex++;
@@ -1065,6 +1059,8 @@ public class Game extends BasicGameState {
 			}
 
 			// stack calculation
+			// more info: https://gist.github.com/peppy/1167470
+			// @author peppy
 			for (int i = hitObjects.length - 1; i > 0; i--) {
 				OsuHitObject hitObjectI = osu.objects[i];
 
@@ -1112,7 +1108,7 @@ public class Game extends BasicGameState {
 							break;
 						}
 					}
-					// no special case. stack moves up left
+					// not a special case. stack moves up left
 					float x1 = hitObjectI.getX();
 					float y1 = hitObjectI.getY();
 					float x2 = hitObjectN.getX();
@@ -1471,6 +1467,16 @@ public class Game extends BasicGameState {
 	 * Returns the beat length.
 	 */
 	public float getBeatLength() { return beatLength; }
+
+	/**
+	 * Sets the beat length fields based on a given timing point.
+	 */
+	private void setBeatLength(OsuTimingPoint timingPoint) {
+		if (!timingPoint.isInherited())
+			beatLengthBase = beatLength = timingPoint.getBeatLength();
+		else
+			beatLength = beatLengthBase * timingPoint.getSliderMultiplier();
+	}
 
 	/**
 	 * Returns the slider multiplier given by the current timing point.


### PR DESCRIPTION
Move slider.sliderTime calculation from update() to constructor. Necessarily for slider.getPointAt() to work properly.
To order to get accurate slider end position, need access to both HitObject and OsuHitObject at same time.
HitObject.updatePosition() is a workaround since we can't calculate stack when hit object initializates.
Algorithm is pretty solid. Some numbers (STACK_LENIENCE, STACK_TIMEOUT, stackModifier etc) can be a little bit off.