### PR TITLE
Fullscreen resizing fix 

### DIFF
--- a/src/itdelatrisu/opsu/Container.java
+++ b/src/itdelatrisu/opsu/Container.java
@@ -133,7 +133,7 @@ public class Container extends AppGameContainer {
 		// reset BeatmapSetList data
 		if (BeatmapSetList.get() != null)
 			BeatmapSetList.get().reset();
-		
+
 		// delete OpenGL objects involved in the Curve rendering
 		CurveRenderState.shutdown();
 	}

--- a/src/itdelatrisu/opsu/Container.java
+++ b/src/itdelatrisu/opsu/Container.java
@@ -23,6 +23,7 @@ import itdelatrisu.opsu.beatmap.Beatmap;
 import itdelatrisu.opsu.beatmap.BeatmapSetList;
 import itdelatrisu.opsu.downloads.DownloadList;
 import itdelatrisu.opsu.downloads.Updater;
+import itdelatrisu.opsu.render.CurveRenderState;
 import itdelatrisu.opsu.ui.UI;
 
 import org.lwjgl.opengl.Display;
@@ -132,6 +133,9 @@ public class Container extends AppGameContainer {
 		// reset BeatmapSetList data
 		if (BeatmapSetList.get() != null)
 			BeatmapSetList.get().reset();
+		
+		// delete OpenGL objects involved in the Curve rendering
+		CurveRenderState.shutdown();
 	}
 
 	@Override

--- a/src/itdelatrisu/opsu/render/CurveRenderState.java
+++ b/src/itdelatrisu/opsu/render/CurveRenderState.java
@@ -451,6 +451,8 @@ public class CurveRenderState {
 					String error = GL20.glGetProgramInfoLog(program, 1024);
 					Log.error("Program linking failed.", new Exception(error));
 				}
+				GL20.glDeleteShader(vtxShdr);
+				GL20.glDeleteShader(frgShdr);
 				attribLoc = GL20.glGetAttribLocation(program, "in_position");
 				texCoordLoc = GL20.glGetAttribLocation(program, "in_tex_coord");
 				texLoc = GL20.glGetUniformLocation(program, "tex");

--- a/src/itdelatrisu/opsu/render/CurveRenderState.java
+++ b/src/itdelatrisu/opsu/render/CurveRenderState.java
@@ -75,7 +75,12 @@ public class CurveRenderState {
 		//scale = scale * 118 / 128; //for curves exactly as big as the sliderball
 		FrameBufferCache.init(width, height);
 	}
-	
+
+	/**
+	 * Undo the static state. Static state setup caused by calls to 
+	 * {@link #draw(org.newdawn.slick.Color, org.newdawn.slick.Color, itdelatrisu.opsu.objects.curves.Vec2f[])}
+	 * are undone.
+	 */
 	public static void shutdown()
 	{
 		staticState.shutdown();
@@ -144,7 +149,7 @@ public class CurveRenderState {
 	}
 
 	/**
-	 * Discard the cache.
+	 * Discard the cache mapping for this curve object
 	 */
 	public void discardCache() {
 		fbo = null;
@@ -454,14 +459,17 @@ public class CurveRenderState {
 			}
 		}
 
+		/**
+		 * Cleanup any OpenGL objects that may have been initialized.
+		 */
 		private void shutdown()
 		{
 			if(gradientTexture != 0)
 			{
-			GL11.glDeleteTextures(gradientTexture);
-			gradientTexture = 0;
+				GL11.glDeleteTextures(gradientTexture);
+				gradientTexture = 0;
 			}
-			
+
 			if(program != 0)
 			{
 				GL20.glDeleteProgram(program);

--- a/src/itdelatrisu/opsu/render/CurveRenderState.java
+++ b/src/itdelatrisu/opsu/render/CurveRenderState.java
@@ -75,6 +75,12 @@ public class CurveRenderState {
 		//scale = scale * 118 / 128; //for curves exactly as big as the sliderball
 		FrameBufferCache.init(width, height);
 	}
+	
+	public static void shutdown()
+	{
+		staticState.shutdown();
+		FrameBufferCache.shutdown();
+	}
 
 	/**
 	 * Creates an object to hold the render state that's necessary to draw a curve.
@@ -445,6 +451,26 @@ public class CurveRenderState {
 				texLoc = GL20.glGetUniformLocation(program, "tex");
 				colLoc = GL20.glGetUniformLocation(program, "col_tint");
 				colBorderLoc = GL20.glGetUniformLocation(program, "col_border");
+			}
+		}
+
+		private void shutdown()
+		{
+			if(gradientTexture != 0)
+			{
+			GL11.glDeleteTextures(gradientTexture);
+			gradientTexture = 0;
+			}
+			
+			if(program != 0)
+			{
+				GL20.glDeleteProgram(program);
+				program = 0;
+				attribLoc = 0;
+				texCoordLoc = 0;
+				colLoc = 0;
+				colBorderLoc = 0;
+				texLoc = 0;
 			}
 		}
 	}

--- a/src/itdelatrisu/opsu/render/FrameBufferCache.java
+++ b/src/itdelatrisu/opsu/render/FrameBufferCache.java
@@ -122,6 +122,20 @@ public class FrameBufferCache {
 		return buffer;
 	}
 
+	public static void shutdown()
+	{
+		//if there were any previous Framebuffers in the cache delete them
+		//this is necessary for cases when the game gets re-started with a
+		//different resolution without closing the process
+		FrameBufferCache fbcInstance = FrameBufferCache.getInstance();
+		for(Rendertarget target: fbcInstance.cache)
+		{
+			target.destroyRTT();
+		}
+		fbcInstance.cache.clear();
+		fbcInstance.freeMap();
+	}
+
 	/**
 	 * There should only ever be one framebuffer cache, this function returns
 	 * that one framebuffer cache instance.

--- a/src/itdelatrisu/opsu/render/FrameBufferCache.java
+++ b/src/itdelatrisu/opsu/render/FrameBufferCache.java
@@ -122,11 +122,14 @@ public class FrameBufferCache {
 		return buffer;
 	}
 
+	/**
+	 * Clear the cache pool of Framebuffers.
+	 * If there were any previous Framebuffers in the cache delete them
+	 * this is necessary for cases when the game gets re-started with a
+	 * different resolution without closing the process
+	 */
 	public static void shutdown()
 	{
-		//if there were any previous Framebuffers in the cache delete them
-		//this is necessary for cases when the game gets re-started with a
-		//different resolution without closing the process
 		FrameBufferCache fbcInstance = FrameBufferCache.getInstance();
 		for(Rendertarget target: fbcInstance.cache)
 		{

--- a/src/itdelatrisu/opsu/render/Rendertarget.java
+++ b/src/itdelatrisu/opsu/render/Rendertarget.java
@@ -40,7 +40,7 @@ public class Rendertarget {
 
 	/** The renderbuffer ID for the depth buffer that this rendertarget renders into. */
 	private final int depthBufferID;
-	
+
 	/**
 	 * Create a new FBO.
 	 * @param width the width
@@ -115,7 +115,7 @@ public class Rendertarget {
 
 		return buffer;
 	}
-	
+
 	/**
 	 * Destroy the OpenGL objects associated with this Rendertarget. Do not try
 	 * to use this rendertarget with OpenGL after calling this method.

--- a/src/itdelatrisu/opsu/render/Rendertarget.java
+++ b/src/itdelatrisu/opsu/render/Rendertarget.java
@@ -35,9 +35,12 @@ public class Rendertarget {
 	/** The FBO ID. */
 	private final int fboID;
 
-	/** The texture ID. */
+	/** The texture ID. for the color buffer this rendertarget renders into. */
 	private final int textureID;
 
+	/** The renderbuffer ID for the depth buffer that this rendertarget renders into. */
+	private final int depthBufferID;
+	
 	/**
 	 * Create a new FBO.
 	 * @param width the width
@@ -48,6 +51,7 @@ public class Rendertarget {
 		this.height = height;
 		fboID = GL30.glGenFramebuffers();
 		textureID = GL11.glGenTextures();
+		depthBufferID = GL30.glGenRenderbuffers();
 	}
 
 	/**
@@ -99,10 +103,9 @@ public class Rendertarget {
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MIN_FILTER, GL11.GL_NEAREST);
 		GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
 
-		int fboDepth = GL30.glGenRenderbuffers();
-		GL30.glBindRenderbuffer(GL30.GL_RENDERBUFFER, fboDepth);
+		GL30.glBindRenderbuffer(GL30.GL_RENDERBUFFER, buffer.depthBufferID);
 		GL30.glRenderbufferStorage(GL30.GL_RENDERBUFFER, GL11.GL_DEPTH_COMPONENT, width, height);
-		GL30.glFramebufferRenderbuffer(GL30.GL_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL30.GL_RENDERBUFFER, fboDepth);
+		GL30.glFramebufferRenderbuffer(GL30.GL_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, GL30.GL_RENDERBUFFER, buffer.depthBufferID);
 
 		GL32.glFramebufferTexture(GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0, fboTexture, 0);
 		GL20.glDrawBuffers(GL30.GL_COLOR_ATTACHMENT0);
@@ -111,5 +114,16 @@ public class Rendertarget {
 		GL30.glBindFramebuffer(GL30.GL_DRAW_FRAMEBUFFER, old_framebuffer);
 
 		return buffer;
+	}
+	
+	/**
+	 * Destroy the OpenGL objects associated with this Rendertarget. Do not try
+	 * to use this rendertarget with OpenGL after calling this method.
+	 */
+	public void destroyRTT()
+	{
+		GL30.glDeleteFramebuffers(fboID);
+		GL30.glDeleteRenderbuffers(depthBufferID);
+		GL11.glDeleteTextures(textureID);
 	}
 }


### PR DESCRIPTION
related to #101

Correctly clean up the created OpenGL objects created for the slider rendering.

This is necessary because the OpenGL context being closed does apparently not close
the process and the game can be restarted with another resolution without shutting
down the process completely.


Not really sure what else to do to cleanly shut this down, I'll add some more comments in a moment
