### PR TITLE
Make the XDG-option available from command line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ mainClassName = 'itdelatrisu.opsu.Opsu'
 buildDir = new File(rootProject.projectDir, "build/")
 
 def useXDG = 'false'
+if(hasProperty('XDG')) {
+	useXDG = XDG
+}
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7


### PR DESCRIPTION
I've found no way to access it without this workaround: https://discuss.gradle.org/t/can-i-override-the-group-property-from-the-command-line/5294
It's now possible to build with `gradle jar -PXDG=true`.