### PR TITLE
Improve slider rendering.

### DIFF
--- a/src/itdelatrisu/opsu/GameData.java
+++ b/src/itdelatrisu/opsu/GameData.java
@@ -389,7 +389,7 @@ public class GameData {
 		if (hitResultList != null) {
 			for (HitObjectResult hitResult : hitResultList) {
 				if (hitResult.curve != null)
-					hitResult.curve.discardCache();
+					hitResult.curve.discardGeometry();
 			}
 		}
 		hitResultList = new LinkedBlockingDeque<HitObjectResult>();
@@ -943,7 +943,7 @@ public class GameData {
 				hitResult.alpha = 1 - ((float) (trackPosition - hitResult.time) / HITRESULT_FADE_TIME);
 			} else {
 				if (hitResult.curve != null)
-					hitResult.curve.discardCache();
+					hitResult.curve.discardGeometry();
 				iter.remove();
 			}
 		}

--- a/src/itdelatrisu/opsu/objects/curves/Curve.java
+++ b/src/itdelatrisu/opsu/objects/curves/Curve.java
@@ -95,12 +95,12 @@ public abstract class Curve {
 		Curve.borderColor = borderColor;
 
 		ContextCapabilities capabilities = GLContext.getCapabilities();
-		mmsliderSupported = capabilities.GL_EXT_framebuffer_object;
+		mmsliderSupported = capabilities.OpenGL20;
 		if (mmsliderSupported)
 			CurveRenderState.init(width, height, circleDiameter);
 		else {
 			if (Options.getSkin().getSliderStyle() != Skin.STYLE_PEPPYSLIDER)
-				Log.warn("New slider style requires FBO support.");
+				Log.warn("New slider style requires OpenGL 2.0.");
 		}
 	}
 
@@ -172,8 +172,8 @@ public abstract class Curve {
 	/**
 	 * Discards the slider cache (only used for mmsliders).
 	 */
-	public void discardCache() {
+	public void discardGeometry() {
 		if (renderState != null)
-			renderState.discardCache();
+			renderState.discardGeometry();
 	}
 }

--- a/src/itdelatrisu/opsu/render/CurveRenderState.java
+++ b/src/itdelatrisu/opsu/render/CurveRenderState.java
@@ -585,7 +585,7 @@ public class CurveRenderState {
 						+ "varying vec2 tex_coord;\n"
 						+ "void main()\n"
 						+ "{\n"
-						+ "    gl_Position = vec4(vec2(-1.f,1.f)+inv_screensize*in_position.xy,in_position.zw);\n"
+						+ "    gl_Position = vec4(vec2(-1.0,1.0)+inv_screensize*in_position.xy,in_position.zw);\n"
 						+ "    tex_coord = in_tex_coord;\n"
 						+ "}");
 				GL20.glCompileShader(vtxShdr);


### PR DESCRIPTION
The old code created a framebuffer for every slider drawn, which results in a major performance loss, especially on shared memory systems like integrated GPUs.
The new codes renders a 'ramp', not individual cones, so the sliders look extra smooth.
Also, there is no framebuffer involved, meaning the new sliders can be used on more systems.