### PR TITLE
Add option to disable ranking elements animation

### DIFF
--- a/src/itdelatrisu/opsu/OptionGroup.java
+++ b/src/itdelatrisu/opsu/OptionGroup.java
@@ -57,7 +57,8 @@ public class OptionGroup {
 			GameOption.SHOW_COMBO_BURSTS,
 			GameOption.SHOW_PERFECT_HIT,
 			GameOption.SHOW_FOLLOW_POINTS,
-			GameOption.SHOW_HIT_ERROR_BAR
+			GameOption.SHOW_HIT_ERROR_BAR,
+			GameOption.ANIMATE_RANKING
 		}),
 		new OptionGroup("Input", new GameOption[] {
 			GameOption.KEY_LEFT,

--- a/src/itdelatrisu/opsu/Options.java
+++ b/src/itdelatrisu/opsu/Options.java
@@ -617,6 +617,7 @@ public class Options {
 						val - TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(val)));
 			}
 		},
+		ANIMATE_RANKING ("Animate Ranking Elements", "RankingElementsAnimation", "Animate the ranking details after completing a map.", true),
 		PARALLAX ("Parallax", "MenuParallax", "Add a parallax effect based on the current cursor position.", true),
 		ENABLE_THEME_SONG ("Enable Theme Song", "MenuMusic", "Whether to play the theme song upon starting opsu!", true),
 		REPLAY_SEEKING ("Replay Seeking", "ReplaySeeking", "Enable a seeking bar on the left side of the screen during replays.", false),
@@ -1144,6 +1145,12 @@ public class Options {
 	 * @return true if Unicode preferred
 	 */
 	public static boolean useUnicodeMetadata() { return GameOption.SHOW_UNICODE.getBooleanValue(); }
+
+	/**
+	 * Returns whether or not to animate ranking elements
+	 * @return true if animation is enabled
+	 */
+	public static boolean isRankingElementsAnimationEnabled() { return GameOption.ANIMATE_RANKING.getBooleanValue(); }
 
 	/**
 	 * Returns whether parallax is enabled.

--- a/src/itdelatrisu/opsu/states/GameRanking.java
+++ b/src/itdelatrisu/opsu/states/GameRanking.java
@@ -130,6 +130,9 @@ public class GameRanking extends BasicGameState {
 		}
 
 		// ranking screen elements
+		if (!Options.isRankingElementsAnimationEnabled()) {
+			animationProgress.setTime(animationProgress.getDuration());
+		}
 		data.drawRankingElements(g, beatmap, animationProgress.getTime());
 
 		// buttons


### PR DESCRIPTION
Fixes #231

I wasn't sure where to put the option, so I put it under gameplay. The internal option is specified just before the parallax option.