### PR TITLE
Show restart button for options that require a restart

### DIFF
--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -319,6 +319,9 @@ public class Options {
 		SCREEN_RESOLUTION ("Resolution", "ScreenResolution", "") {
 			private Resolution[] itemList = null;
 
+		        @Override
+		        public boolean isRestartRequired() { return true; }
+
 			@Override
 			public String getValueString() { return resolution.toString(); }
 
@@ -356,6 +359,9 @@ public class Options {
 			}
 		},
 		FULLSCREEN ("Fullscreen mode", "Fullscreen", "Switches to dedicated fullscreen mode.", false) {
+		        @Override
+		        public boolean isRestartRequired() { return true; }
+
 			@Override
 			public void toggle(GameContainer container) {
 				// check if fullscreen mode is possible with this resolution
@@ -369,6 +375,9 @@ public class Options {
 		},
 		SKIN ("Skin", "Skin", "") {
 			private String[] itemList = null;
+
+			@Override
+                        public boolean isRestartRequired() { return true; }
 
 			/** Creates the list of available skins. */
 			private void createSkinList() {
@@ -525,7 +534,10 @@ public class Options {
 			@Override
 			public String getValueString() { return String.format("%dms", val); }
 		},
-		DISABLE_SOUNDS ("Disable all sound effects", "DisableSound", "May resolve Linux sound driver issues.\nRequires a restart.", false),
+		DISABLE_SOUNDS ("Disable all sound effects", "DisableSound", "May resolve Linux sound driver issues.\nRequires a restart.", false) {
+		        @Override
+		        public boolean isRestartRequired() { return true; }
+		},
 		KEY_LEFT ("Left game key", "keyOsuLeft", "Select this option to input a key.") {
 			@Override
 			public String getValueString() { return Keyboard.getKeyName(getGameKeyLeft()); }
@@ -643,7 +655,10 @@ public class Options {
 		ENABLE_THEME_SONG ("Theme song", "MenuMusic", OpsuConstants.PROJECT_NAME + " will play themed music throughout the game, instead of using random beatmaps.", true),
 		REPLAY_SEEKING ("Replay seeking", "ReplaySeeking", "Enable a seeking bar on the left side of the screen during replays.", false),
 		DISABLE_UPDATER ("Disable automatic updates", "DisableUpdater", "Disable checking for updates when the game starts.", false),
-		ENABLE_WATCH_SERVICE ("Watch service", "WatchService", "Watch the beatmap directory for changes. Requires a restart.", false);
+		ENABLE_WATCH_SERVICE ("Watch service", "WatchService", "Watch the beatmap directory for changes. Requires a restart.", false) {
+			@Override
+                        public boolean isRestartRequired() { return true; }
+		};
 
 		/** Option name. */
 		private final String name;
@@ -743,6 +758,12 @@ public class Options {
 		 * @return the type
 		 */
 		public OptionType getType() { return type; }
+
+		/**
+		 * Returns whether a restart is required for the option to take effect.
+		 * @return true if a restart is required, false otherwise
+		 */
+		public boolean isRestartRequired() { return false; }
 
 		/**
 		 * Returns the boolean value for the option, if applicable.

--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -319,8 +319,8 @@ public class Options {
 		SCREEN_RESOLUTION ("Resolution", "ScreenResolution", "") {
 			private Resolution[] itemList = null;
 
-		        @Override
-		        public boolean isRestartRequired() { return true; }
+			@Override
+			public boolean isRestartRequired() { return true; }
 
 			@Override
 			public String getValueString() { return resolution.toString(); }
@@ -359,8 +359,8 @@ public class Options {
 			}
 		},
 		FULLSCREEN ("Fullscreen mode", "Fullscreen", "Switches to dedicated fullscreen mode.", false) {
-		        @Override
-		        public boolean isRestartRequired() { return true; }
+			@Override
+			public boolean isRestartRequired() { return true; }
 
 			@Override
 			public void toggle(GameContainer container) {
@@ -377,7 +377,7 @@ public class Options {
 			private String[] itemList = null;
 
 			@Override
-                        public boolean isRestartRequired() { return true; }
+			public boolean isRestartRequired() { return true; }
 
 			/** Creates the list of available skins. */
 			private void createSkinList() {
@@ -535,8 +535,8 @@ public class Options {
 			public String getValueString() { return String.format("%dms", val); }
 		},
 		DISABLE_SOUNDS ("Disable all sound effects", "DisableSound", "May resolve Linux sound driver issues.\nRequires a restart.", false) {
-		        @Override
-		        public boolean isRestartRequired() { return true; }
+			@Override
+			public boolean isRestartRequired() { return true; }
 		},
 		KEY_LEFT ("Left game key", "keyOsuLeft", "Select this option to input a key.") {
 			@Override
@@ -657,7 +657,7 @@ public class Options {
 		DISABLE_UPDATER ("Disable automatic updates", "DisableUpdater", "Disable checking for updates when the game starts.", false),
 		ENABLE_WATCH_SERVICE ("Watch service", "WatchService", "Watch the beatmap directory for changes. Requires a restart.", false) {
 			@Override
-                        public boolean isRestartRequired() { return true; }
+			public boolean isRestartRequired() { return true; }
 		};
 
 		/** Option name. */

--- a/src/itdelatrisu/opsu/options/OptionsOverlay.java
+++ b/src/itdelatrisu/opsu/options/OptionsOverlay.java
@@ -317,7 +317,7 @@ public class OptionsOverlay extends AbstractComponent {
 						option.selectItem(index, OptionsOverlay.this.container);
 
 						// show restart button?
-						if (option == GameOption.SCREEN_RESOLUTION || option == GameOption.SKIN) {
+						if (option.isRestartRequired()) {
 							showRestartButton = true;
 							UI.getNotificationManager().sendBarNotification("Restart to apply changes.");
 						}
@@ -1017,7 +1017,7 @@ public class OptionsOverlay extends AbstractComponent {
 				hoverOption.toggle(container);
 
 				// show restart button?
-				if (oldValue != hoverOption.getBooleanValue() && hoverOption == GameOption.FULLSCREEN) {
+				if (oldValue != hoverOption.getBooleanValue() && hoverOption.isRestartRequired()) {
 					showRestartButton = true;
 					UI.getNotificationManager().sendBarNotification("Restart to apply changes.");
 				}


### PR DESCRIPTION
Add a new method `isRestartRequired` to the `GameOption` enum that returns `true` if the option requires a restart to take effect. The method returns `false` by default and the option should override this if `true` is needed. This approach is less messy than adding a flag to the various constructors.

The restart button was previously not shown for the following options:
- `DISABLE_SOUNDS`
- `ENABLE_WATCH_SERVICE`

The restart button continues to be shown for the following options:
- `SCREEN_RESOLUTION`
- `FULLSCREEN`
- `SKIN`