### PR TITLE
Issue 266

### DIFF
--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -377,6 +377,11 @@ public class Slider implements GameObject {
 	 * @param decorationsAlpha the decorations alpha level
 	 */
 	private void drawSliderTicks(int trackPosition, float curveAlpha, float decorationsAlpha) {
+		// don't draw if the slider would be completely finished (occurs when game is in losing state)
+		if (trackPosition > hitObject.getTime() + sliderTimeTotal) {
+			return;
+		}
+
 		float tickScale = 0.5f + 0.5f * AnimationEquation.OUT_BACK.calc(decorationsAlpha);
 		Image tick = GameImage.SLIDER_TICK.getImage().getScaledCopy(tickScale);
 

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -434,7 +434,7 @@ public class Slider implements GameObject {
 		int curveLength = curve.getCurvePoints().length;
 
 		// merging sliders
-		if (Options.isExperimentalSliderMerging()) {
+		if (Options.isExperimentalSliderMerging() && !game.isInLosingState()) {
 			if (Options.isExperimentalSliderShrinking() && curveIntervalFrom > 0) {
 				if (hitObject.getRepeatCount() % 2 == 0) {
 					game.addMergedSliderPointsToRender(

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -1629,12 +1629,6 @@ public class Game extends BasicGameState {
 		// draw result objects (under)
 		data.drawHitResults(trackPosition, false);
 
-		// draw merged slider
-		if (mergedSlider != null && Options.isExperimentalSliderMerging()) {
-			mergedSlider.draw(Color.white);
-			mergedSlider.clearPoints();
-		}
-
 		// include previous object in follow points
 		int lastObjectIndex = -1;
 		if (objectIndex > 0 && objectIndex < beatmap.objects.length &&
@@ -1644,6 +1638,12 @@ public class Game extends BasicGameState {
 		boolean loseState = (restart == Restart.LOSE);
 		if (loseState)
 			trackPosition = failTrackTime + (int) (System.currentTimeMillis() - failTime);
+
+		// draw merged slider
+		if (!loseState && mergedSlider != null && Options.isExperimentalSliderMerging()) {
+			mergedSlider.draw(Color.white);
+			mergedSlider.clearPoints();
+		}
 
 		// get hit objects in reverse order, or else overlapping objects are unreadable
 		Stack<Integer> stack = new Stack<Integer>();
@@ -2402,4 +2402,9 @@ public class Game extends BasicGameState {
 			BeatmapDB.updateLocalOffset(beatmap);
 		}
 	}
+
+	public boolean isInLosingState() {
+		return restart == Restart.LOSE;
+	}
+
 }

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -2403,6 +2403,9 @@ public class Game extends BasicGameState {
 		}
 	}
 
+	/**
+	 * Returns whether or not the game is in losing state.
+	 */
 	public boolean isInLosingState() {
 		return restart == Restart.LOSE;
 	}


### PR DESCRIPTION
fix for #266, by forcing non-merged sliders when the game is in losing state.
* Also added a check to not draw sliderticks when slider is finished, it caused the ticks being shown when the slider should be finished when the objects are falling when losing.
* When losing with shrinking sliders enabled, the initial circle keeps showing while the slidertrack may already have disappeared. The shrinking seems okay as the sliderball also continues to moves (as pointed out by @tpenguinltg), but it might look a bit weird because the initial circle stays, not sure if it needs to be changed.