### PR TITLE
Add options button to main menu

### DIFF
--- a/src/itdelatrisu/opsu/options/OptionsOverlay.java
+++ b/src/itdelatrisu/opsu/options/OptionsOverlay.java
@@ -365,7 +365,6 @@ public class OptionsOverlay extends AbstractComponent {
 		if (dropdownMenus == null)
 			createDropdownMenus();
 		resetSearch();
-		searchField.setFocus(true);
 		for (Map.Entry<GameOption, DropdownMenu<Object>> entry : dropdownMenus.entrySet()) {
 			GameOption option = entry.getKey();
 			DropdownMenu<Object> menu = entry.getValue();
@@ -1068,6 +1067,7 @@ public class OptionsOverlay extends AbstractComponent {
 
 		searchField.setFocus(true);
 		searchField.keyPressed(key, c);
+		searchField.setFocus(false);
 		if (!searchField.getText().equals(lastSearchText)) {
 			lastSearchText = searchField.getText().toLowerCase();
 			updateSearch();

--- a/src/itdelatrisu/opsu/states/MainMenu.java
+++ b/src/itdelatrisu/opsu/states/MainMenu.java
@@ -925,6 +925,12 @@ public class MainMenu extends BasicGameState {
 		case Input.KEY_DOWN:
 			UI.changeVolume(-1);
 			break;
+		case Input.KEY_O:
+			SoundController.playSound(SoundEffect.MENUHIT);
+			showOptionsOverlay = true;
+			optionsOverlayProgress.setTime(0);
+			optionsOverlay.activate();
+			break;
 		}
 	}
 

--- a/src/itdelatrisu/opsu/states/MainMenu.java
+++ b/src/itdelatrisu/opsu/states/MainMenu.java
@@ -926,10 +926,12 @@ public class MainMenu extends BasicGameState {
 			UI.changeVolume(-1);
 			break;
 		case Input.KEY_O:
-			SoundController.playSound(SoundEffect.MENUHIT);
-			showOptionsOverlay = true;
-			optionsOverlayProgress.setTime(0);
-			optionsOverlay.activate();
+			if (input.isKeyDown(Input.KEY_RCONTROL) || input.isKeyDown(Input.KEY_LCONTROL)) {
+				SoundController.playSound(SoundEffect.MENUHIT);
+				showOptionsOverlay = true;
+				optionsOverlayProgress.setTime(0);
+				optionsOverlay.activate();
+			}
 			break;
 		}
 	}

--- a/src/itdelatrisu/opsu/states/MainMenu.java
+++ b/src/itdelatrisu/opsu/states/MainMenu.java
@@ -733,6 +733,25 @@ public class MainMenu extends BasicGameState {
 	}
 
 	@Override
+	public void mouseClicked(int button, int x, int y, int clickCount) {
+		// check mouse button
+		if (button == Input.MOUSE_MIDDLE_BUTTON)
+			return;
+
+		if (showOptionsOverlay || !optionsOverlayProgress.isFinished())
+			return;
+
+		// options button
+		if (selectOptionsButton.contains(x, y)) {
+			SoundController.playSound(SoundEffect.MENUHIT);
+			showOptionsOverlay = true;
+			optionsOverlayProgress.setTime(0);
+			optionsOverlay.activate();
+			return;
+		}
+	}
+
+	@Override
 	public void mousePressed(int button, int x, int y) {
 		// check mouse button
 		if (button == Input.MOUSE_MIDDLE_BUTTON)
@@ -780,15 +799,6 @@ public class MainMenu extends BasicGameState {
 			SoundController.playSound(SoundEffect.MENUHIT);
 			((ButtonMenu) game.getState(Opsu.STATE_BUTTONMENU)).setMenuState(MenuState.ABOUT);
 			game.enterState(Opsu.STATE_BUTTONMENU);
-			return;
-		}
-
-		// options button actions
-		if (selectOptionsButton.contains(x, y)) {
-			SoundController.playSound(SoundEffect.MENUHIT);
-			showOptionsOverlay = true;
-			optionsOverlayProgress.setTime(0);
-			optionsOverlay.activate();
 			return;
 		}
 


### PR DESCRIPTION
Adding this button to the main menu allows a new user (i.e. one who has no beatmaps) to access the options without installing a beatmap.
We may also want to consider making a new image so that it doesn't say "Other Options" when there are no other options on that screen.

Fixes #279