### PR TITLE
Fix regular snaking sliders

### DIFF
--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -217,7 +217,7 @@ public class Slider implements GameObject {
 
 		boolean isCurveCompletelyDrawn;
 		if (!Options.isExperimentalSliderStyle()) {
-			isCurveCompletelyDrawn = Options.isSliderSnaking() || alpha == 1f;
+			isCurveCompletelyDrawn = !Options.isSliderSnaking() || alpha == 1f;
 			curve.draw(color, isCurveCompletelyDrawn ? 1f : alpha);
 		} else {
 			isCurveCompletelyDrawn = drawExperimentalSliderTrack(trackPosition, Utils.clamp(1d - (double) (timeDiff - approachTime + fadeInTime) / fadeInTime, 0d, 1d), sliderAlpha);


### PR DESCRIPTION
Fix snaking sliders not snaking with regular sliders (introduced by 0ad8291). This was a logic error.

isCurveCompletelyDrawn <==> (snaking => alpha == 1)
"The curve is completely drawn if and only if snaking implies alpha = 1".
A implies B is the same as (NOT A) OR B.

Fixes #286