### PR TITLE
fix slidercaps being drawn when they shouldn't

### DIFF
--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -224,9 +224,10 @@ public class Slider implements GameObject {
 			color.a = alpha;
 		}
 
+		boolean drawSliderCaps = !Options.isExperimentalSliderStyle() || Options.isExperimentalSliderCapsDrawn();
+
 		// end circle (only draw if ball still has to go there)
-		if (isCurveCompletelyDrawn && currentRepeats < repeatCount - (repeatCount % 2 == 0 ? 1 : 0) &&
-		    (!Options.isExperimentalSliderStyle() || Options.isExperimentalSliderCapsDrawn())) {
+		if (drawSliderCaps && isCurveCompletelyDrawn && currentRepeats < repeatCount - (repeatCount % 2 == 0 ? 1 : 0)) {
 			Color circleColor = new Color(color);
 			Color overlayColor = new Color(Colors.WHITE_FADE);
 			if (currentRepeats == 0) {
@@ -252,7 +253,7 @@ public class Slider implements GameObject {
 		}
 
 		// start circle, only draw if ball still has to go there
-		if (!sliderClickedInitial || currentRepeats < repeatCount - (repeatCount % 2 == 1 ? 1 : 0)) {
+		if (!sliderClickedInitial || (drawSliderCaps && currentRepeats < repeatCount - (repeatCount % 2 == 1 ? 1 : 0))) {
 			hitCircle.drawCentered(x, y, firstCircleColor);
 			if (!overlayAboveNumber || sliderClickedInitial)
 				hitCircleOverlay.drawCentered(x, y, startCircleOverlayColor);


### PR DESCRIPTION
Slidercaps are being draw on the initial circle when experimental sliders are enabled while the slider caps option is disabled (blame 0ad8291 from pull request #263).
Incorrect behavior can be easily seen on the osu! tutorial map on every slider with reverse arrows. 
The commit inside this pull request fixes that.