### PR TITLE
Filter beatmap sets based on conditional searches (eg: AR>9)

### DIFF
--- a/src/itdelatrisu/opsu/states/ButtonMenu.java
+++ b/src/itdelatrisu/opsu/states/ButtonMenu.java
@@ -488,7 +488,7 @@ public class ButtonMenu extends BasicGameState {
 			public void click(GameContainer container, StateBasedGame game) {
 				SoundController.playSound(SoundEffect.MENUHIT);
 				BeatmapSetNode node = ((ButtonMenu) game.getState(Opsu.STATE_BUTTONMENU)).getNode();
-				MenuState ms = (node.beatmapIndex == -1 || node.getBeatmapSet().size() == 1) ?
+				MenuState ms = (node.beatmapIndex == -1 || node.getBeatmapSet().trueSize() == 1) ?
 						MenuState.BEATMAP_DELETE_CONFIRM : MenuState.BEATMAP_DELETE_SELECT;
 				((ButtonMenu) game.getState(Opsu.STATE_BUTTONMENU)).setMenuState(ms, node);
 				game.enterState(Opsu.STATE_BUTTONMENU);


### PR DESCRIPTION
In osu! you can search for maps via conditionals like AR>=9 and only maps that match that criteria are returned.

opsu has the same functionality however the entire set is returned, a majority of sets are going to contain maps with things like stars>4 etc so returning the entire set makes it hard to see exactly what you're after.

This change will filter the beatmaps within a beatmap set on conditional searches so that only matches based on the condition are shown in game.