### PR TITLE
Add option "Unlimited" on frame limiter

### DIFF
--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -987,7 +987,7 @@ public class Options {
 	 * @param container the game container
 	 */
 	public static void setNextFPS(GameContainer container) {
-		int index = (targetFPSindex + 1) % (targetFPS.length - 1);
+		int index = (targetFPSindex + 1) % (targetFPS.length - 1); // Skip "Unlimited" option
 		GameOption.TARGET_FPS.selectItem(index, container);
 		UI.getNotificationManager().sendBarNotification(String.format("Frame limiter: %s", GameOption.TARGET_FPS.getValueString()));
 	}

--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -987,7 +987,7 @@ public class Options {
 	 * @param container the game container
 	 */
 	public static void setNextFPS(GameContainer container) {
-		int index = (targetFPSindex + 1) % targetFPS.length;
+		int index = (targetFPSindex + 1) % (targetFPS.length - 1);
 		GameOption.TARGET_FPS.selectItem(index, container);
 		UI.getNotificationManager().sendBarNotification(String.format("Frame limiter: %s", GameOption.TARGET_FPS.getValueString()));
 	}

--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -399,8 +399,7 @@ public class Options {
 
 			@Override
 			public String getValueString() {
-				return String.format((getTargetFPS() == -1) ? "Unlimited" : 
-					(getTargetFPS() == 60) ? "%dfps (vsync)" : "%dfps", getTargetFPS());
+				return String.format((getTargetFPS() == 60) ? "%dfps (vsync)" : "%dfps", getTargetFPS());
 			}
 
 			@Override

--- a/src/itdelatrisu/opsu/options/Options.java
+++ b/src/itdelatrisu/opsu/options/Options.java
@@ -399,7 +399,8 @@ public class Options {
 
 			@Override
 			public String getValueString() {
-				return String.format((getTargetFPS() == 60) ? "%dfps (vsync)" : "%dfps", getTargetFPS());
+				return String.format((getTargetFPS() == -1) ? "Unlimited" : 
+					(getTargetFPS() == 60) ? "%dfps (vsync)" : "%dfps", getTargetFPS());
 			}
 
 			@Override
@@ -407,7 +408,8 @@ public class Options {
 				if (itemList == null) {
 					itemList = new String[targetFPS.length];
 					for (int i = 0; i < targetFPS.length; i++)
-						itemList[i] = String.format((targetFPS[i] == 60) ? "%dfps (vsync)" : "%dfps", targetFPS[i]);
+						itemList[i] = String.format((targetFPS[i] == -1) ? "Unlimited" : 
+							(targetFPS[i] == 60) ? "%dfps (vsync)" : "%dfps", targetFPS[i]);
 				}
 				return itemList;
 			}
@@ -954,7 +956,7 @@ public class Options {
 	private static Skin skin;
 
 	/** Frame limiters. */
-	private static final int[] targetFPS = { 60, 120, 240 };
+	private static final int[] targetFPS = { 60, 120, 240, -1 };
 
 	/** Index in targetFPS[] array. */
 	private static int targetFPSindex = 0;


### PR DESCRIPTION
Intended for use on benchmarking specific parts of the game, especially during render-intensive scenarios such as during high note densities, testing experimental sliders and the like, but can also be used to decrease input latency by indirectly affecting input polling rate.

Changes to input latency and FPS rates may vary depending on your system configuration.