### PR TITLE
Aspire map patches (fixes #297, #302)

### DIFF
--- a/src/itdelatrisu/opsu/beatmap/BeatmapDifficultyCalculator.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapDifficultyCalculator.java
@@ -119,7 +119,7 @@ public class BeatmapDifficultyCalculator {
 		this.tpHitObjects = new tpHitObject[hitObjects.length];
 		float circleRadius = (PLAYFIELD_WIDTH / 16.0f) * (1.0f - 0.7f * (beatmap.circleSize - 5.0f) / 5.0f);
 		int timingPointIndex = 0;
-		float beatLengthBase = 1, beatLength = 1;
+		double beatLengthBase = 1, beatLength = 1;
 		if (!beatmap.timingPoints.isEmpty()) {
 			TimingPoint timingPoint = beatmap.timingPoints.get(0);
 			if (!timingPoint.isInherited()) {
@@ -324,7 +324,7 @@ class tpHitObject {
 	 * @param beatmap the beatmap that contains the hit object
 	 * @param beatLength the current beat length
 	 */
-	public tpHitObject(HitObject baseHitObject, float circleRadius, Beatmap beatmap, float beatLength) {
+	public tpHitObject(HitObject baseHitObject, float circleRadius, Beatmap beatmap, double beatLength) {
 		this.baseHitObject = baseHitObject;
 
 		// We will scale everything by this factor, so we can assume a uniform CircleSize among beatmaps.
@@ -520,7 +520,7 @@ class tpSlider {
 	 * @param sliderMultiplier the slider movement speed multiplier
 	 * @param beatLength the beat length
 	 */
-	public tpSlider(HitObject hitObject, float sliderMultiplier, float beatLength) {
+	public tpSlider(HitObject hitObject, float sliderMultiplier, double beatLength) {
 		this.startTime = hitObject.getTime();
 		this.sliderTime = (int) hitObject.getSliderTime(sliderMultiplier, beatLength);
 		this.curve = hitObject.getSliderCurve(false);

--- a/src/itdelatrisu/opsu/beatmap/BeatmapHPDropRateCalculator.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapHPDropRateCalculator.java
@@ -92,7 +92,7 @@ public class BeatmapHPDropRateCalculator {
 			int comboTooLowCount = 0;
 			boolean fail = false;
 			int timingPointIndex = 0;
-			float beatLengthBase = 1f, beatLength = 1f;
+			double beatLengthBase = 1f, beatLength = 1f;
 
 			for (int i = 0; i < beatmap.objects.length; i++) {
 				HitObject hitObject = beatmap.objects[i];
@@ -128,8 +128,8 @@ public class BeatmapHPDropRateCalculator {
 				if (hitObject.isCircle())
 					endTime = hitObject.getTime();
 				else if (hitObject.isSlider()) {
-					float sliderTime = hitObject.getSliderTime(beatmap.sliderMultiplier, beatLength);
-					float sliderTimeTotal = sliderTime * hitObject.getRepeatCount();
+					double sliderTime = hitObject.getSliderTime(beatmap.sliderMultiplier, beatLength);
+					double sliderTimeTotal = sliderTime * hitObject.getRepeatCount();
 					endTime = hitObject.getTime() + (int) sliderTimeTotal;
 				} else
 					endTime = hitObject.getEndTime();
@@ -148,7 +148,7 @@ public class BeatmapHPDropRateCalculator {
 
 				// hit objects
 				if (hitObject.isSlider()) {
-					float tickLengthDiv = 100f * beatmap.sliderMultiplier / beatmap.sliderTickRate / (beatLength / beatLengthBase);
+					double tickLengthDiv = 100f * beatmap.sliderMultiplier / beatmap.sliderTickRate / (beatLength / beatLengthBase);
 					int tickCount = (int) Math.ceil(hitObject.getPixelLength() / tickLengthDiv) - 1;
 					for (int j = 0; j < hitObject.getRepeatCount(); j++)
 						health.changeHealthForHit(GameData.HIT_SLIDER30);

--- a/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
@@ -36,6 +36,7 @@ import java.io.InputStreamReader;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -679,6 +680,7 @@ public class BeatmapParser {
 			return;
 
 		beatmap.objects = new HitObject[(beatmap.hitObjectCircle + beatmap.hitObjectSlider + beatmap.hitObjectSpinner)];
+		ArrayList<HitObject> objects = new ArrayList<>();
 
 		try (BufferedReader in = new BufferedReader(new FileReader(beatmap.getFile()))) {
 			String line = in.readLine();
@@ -732,12 +734,21 @@ public class BeatmapParser {
 					hitObject.setComboIndex(comboIndex);
 					hitObject.setComboNumber(comboNumber++);
 
-					beatmap.objects[objectIndex++] = hitObject;
+					objects.add(hitObject);
+					objectIndex++;
 				} catch (Exception e) {
 					Log.warn(String.format("Failed to read hit object '%s' for beatmap '%s'.",
 							line, beatmap.toString()), e);
 				}
 			}
+			objects.trimToSize();
+			Collections.sort(objects, new Comparator<HitObject>() {
+				@Override
+				public int compare(HitObject o1, HitObject o2) {
+					return o1.getTime() - o2.getTime();
+				}
+			});
+			beatmap.objects = objects.toArray(new HitObject[0]);
 
 			// check that all objects were parsed
 			if (objectIndex != beatmap.objects.length)

--- a/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
@@ -35,6 +35,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -680,7 +681,6 @@ public class BeatmapParser {
 			return;
 
 		beatmap.objects = new HitObject[(beatmap.hitObjectCircle + beatmap.hitObjectSlider + beatmap.hitObjectSpinner)];
-		ArrayList<HitObject> objects = new ArrayList<>();
 
 		try (BufferedReader in = new BufferedReader(new FileReader(beatmap.getFile()))) {
 			String line = in.readLine();
@@ -734,21 +734,18 @@ public class BeatmapParser {
 					hitObject.setComboIndex(comboIndex);
 					hitObject.setComboNumber(comboNumber++);
 
-					objects.add(hitObject);
-					objectIndex++;
+					beatmap.objects[objectIndex++] = hitObject;
 				} catch (Exception e) {
 					Log.warn(String.format("Failed to read hit object '%s' for beatmap '%s'.",
 							line, beatmap.toString()), e);
 				}
 			}
-			objects.trimToSize();
-			Collections.sort(objects, new Comparator<HitObject>() {
+			Arrays.sort(beatmap.objects, new Comparator<HitObject>() {
 				@Override
 				public int compare(HitObject o1, HitObject o2) {
 					return o1.getTime() - o2.getTime();
 				}
 			});
-			beatmap.objects = objects.toArray(new HitObject[0]);
 
 			// check that all objects were parsed
 			if (objectIndex != beatmap.objects.length)

--- a/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
@@ -547,7 +547,7 @@ public class BeatmapParser {
 
 							// calculate BPM
 							if (!timingPoint.isInherited()) {
-								int bpm = Math.round(60000 / timingPoint.getBeatLength());
+								int bpm = Math.round(60000 / (float) timingPoint.getBeatLength());
 								if (beatmap.bpmMin == 0) {
 									beatmap.bpmMin = beatmap.bpmMax = bpm;
 								} else if (bpm < beatmap.bpmMin) {

--- a/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
+++ b/src/itdelatrisu/opsu/beatmap/BeatmapParser.java
@@ -562,6 +562,12 @@ public class BeatmapParser {
 						}
 					}
 					beatmap.timingPoints.trimToSize();
+					Collections.sort(beatmap.timingPoints, new Comparator<TimingPoint>() {
+						@Override
+						public int compare(TimingPoint o1, TimingPoint o2) {
+							return (o1.getTime() + (o1.isInherited() ? 1 : 0)) - (o2.getTime() + (o2.isInherited() ? 1 : 0));
+						}
+					});
 					break;
 				case "[Colours]":
 					LinkedList<Color> colors = new LinkedList<Color>();

--- a/src/itdelatrisu/opsu/beatmap/HitObject.java
+++ b/src/itdelatrisu/opsu/beatmap/HitObject.java
@@ -228,7 +228,7 @@ public class HitObject {
 				this.sliderY[j - 1] = Integer.parseInt(sliderXY[1]);
 			}
 			this.repeat = Integer.parseInt(tokens[6]);
-			this.pixelLength = Float.parseFloat(tokens[7]);
+			this.pixelLength = Math.max(Float.parseFloat(tokens[7]), 0);
 			if (tokens.length > 8) {
 				String[] edgeHitSoundTokens = tokens[8].split("\\|");
 				this.edgeHitSound = new byte[edgeHitSoundTokens.length];

--- a/src/itdelatrisu/opsu/beatmap/HitObject.java
+++ b/src/itdelatrisu/opsu/beatmap/HitObject.java
@@ -407,8 +407,8 @@ public class HitObject {
 	 * @param beatLength the beat length
 	 * @return the slider segment length
 	 */
-	public float getSliderTime(float sliderMultiplier, float beatLength) {
-		return beatLength * (pixelLength / sliderMultiplier) / 100f;
+	public double getSliderTime(double sliderMultiplier, double beatLength) {
+		return beatLength * (pixelLength / sliderMultiplier) / 100d;
 	}
 
 	/**

--- a/src/itdelatrisu/opsu/beatmap/TimingPoint.java
+++ b/src/itdelatrisu/opsu/beatmap/TimingPoint.java
@@ -83,7 +83,7 @@ public class TimingPoint {
 
 		// tokens[1] is either beatLength (positive) or velocity (negative)
 		float beatLength = Float.parseFloat(tokens[1]);
-		if (beatLength > 0)
+		if (beatLength >= 0)
 			this.beatLength = beatLength;
 		else {
 			this.velocity = (int) beatLength;

--- a/src/itdelatrisu/opsu/beatmap/TimingPoint.java
+++ b/src/itdelatrisu/opsu/beatmap/TimingPoint.java
@@ -30,7 +30,7 @@ public class TimingPoint {
 	private int time = 0;
 
 	/** Time per beat (in ms). [NON-INHERITED] */
-	private float beatLength = 0f;
+	private double beatLength = 0f;
 
 	/** Slider multiplier. [INHERITED] */
 	private int velocity = 0;
@@ -82,7 +82,7 @@ public class TimingPoint {
 		}
 
 		// tokens[1] is either beatLength (positive) or velocity (negative)
-		float beatLength = Float.parseFloat(tokens[1]);
+		double beatLength = Double.parseDouble(tokens[1]);
 		if (beatLength >= 0)
 			this.beatLength = beatLength;
 		else {
@@ -101,7 +101,7 @@ public class TimingPoint {
 	 * Returns the beat length. [NON-INHERITED]
 	 * @return the time per beat (in ms)
 	 */
-	public float getBeatLength() { return beatLength; }
+	public double getBeatLength() { return beatLength; }
 
 	/**
 	 * Returns the slider multiplier. [INHERITED]

--- a/src/itdelatrisu/opsu/objects/Slider.java
+++ b/src/itdelatrisu/opsu/objects/Slider.java
@@ -76,10 +76,10 @@ public class Slider implements GameObject {
 	private Curve curve;
 
 	/** The time duration of the slider, in milliseconds. */
-	private float sliderTime = 0f;
+	private double sliderTime = 0f;
 
 	/** The time duration of the slider including repeats, in milliseconds. */
-	private float sliderTimeTotal = 0f;
+	private double sliderTimeTotal = 0f;
 
 	/** Whether or not the result of the initial hit circle has been processed. */
 	private boolean sliderClickedInitial = false;
@@ -173,7 +173,7 @@ public class Slider implements GameObject {
 		this.sliderTimeTotal = sliderTime * hitObject.getRepeatCount();
 
 		// ticks
-		float tickLengthDiv = 100f * sliderMultiplier / sliderTickRate / game.getTimingPointMultiplier();
+		double tickLengthDiv = 100f * sliderMultiplier / sliderTickRate / game.getTimingPointMultiplier();
 		int tickCount = (int) Math.ceil(hitObject.getPixelLength() / tickLengthDiv) - 1;
 		if (tickCount > 0) {
 			this.ticksT = new float[tickCount];
@@ -814,7 +814,7 @@ public class Slider implements GameObject {
 	 * @return the t value: raw [0, repeats] or looped [0, 1]
 	 */
 	private float getT(int trackPosition, boolean raw) {
-		float t = (trackPosition - hitObject.getTime()) / sliderTime;
+		float t = (float) ((trackPosition - hitObject.getTime()) / sliderTime);
 		if (raw)
 			return t;
 		else {

--- a/src/itdelatrisu/opsu/objects/curves/EqualDistanceMultiCurve.java
+++ b/src/itdelatrisu/opsu/objects/curves/EqualDistanceMultiCurve.java
@@ -66,6 +66,11 @@ public abstract class EqualDistanceMultiCurve extends Curve {
 
 		float distanceAt = 0;
 		Iterator<CurveType> iter = curvesList.iterator();
+		if(!iter.hasNext()) {
+			// "unrendered" location
+			curve[0] = new Vec2f(-100, -100);
+			return;
+		}
 		int curPoint = 0;
 		CurveType curCurve = iter.next();
 		Vec2f lastCurve = curCurve.getCurvePoint()[0];

--- a/src/itdelatrisu/opsu/render/CurveRenderState.java
+++ b/src/itdelatrisu/opsu/render/CurveRenderState.java
@@ -453,8 +453,8 @@ public class CurveRenderState {
 		GL20.glUniform4f(staticState.colLoc, color.r, color.g, color.b, color.a);
 		GL20.glUniform4f(staticState.colBorderLoc, borderColor.r, borderColor.g, borderColor.b, borderColor.a);
 
-		float lastSegmentX = to == 0 ? curve[1].x - curve[0].x : curve[to].x - curve[to-1].x;
-		float lastSegmentY = to == 0 ? curve[1].y - curve[0].y : curve[to].y - curve[to-1].y;
+		float lastSegmentX = curve.length == 1 ? 0 : to == 0 ? curve[1].x - curve[0].x : curve[to].x - curve[to-1].x;
+		float lastSegmentY = curve.length == 1 ? 0 : to == 0 ? curve[1].y - curve[0].y : curve[to].y - curve[to-1].y;
 		float lastSegmentInvLen = 1.f/(float)Math.hypot(lastSegmentX, lastSegmentY);
 		GL20.glUniform4f(staticState.endPointLoc, curve[to].x, curve[to].y, lastSegmentX * lastSegmentInvLen, lastSegmentY * lastSegmentInvLen);
 		//stride is 6*4 for the floats (4 bytes) (u,v)(x,y,z,w)

--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -187,7 +187,7 @@ public class Game extends BasicGameState {
 	private int timingPointIndex;
 
 	/** Current beat lengths (base value and inherited value). */
-	private float beatLengthBase, beatLength;
+	private double beatLengthBase, beatLength;
 
 	/** Whether the countdown sound has been played. */
 	private boolean
@@ -2093,7 +2093,7 @@ public class Game extends BasicGameState {
 	/**
 	 * Returns the beat length.
 	 */
-	public float getBeatLength() { return beatLength; }
+	public double getBeatLength() { return beatLength; }
 
 	/**
 	 * Sets the beat length fields based on a given timing point.
@@ -2114,7 +2114,7 @@ public class Game extends BasicGameState {
 	/**
 	 * Returns the slider multiplier given by the current timing point.
 	 */
-	public float getTimingPointMultiplier() { return beatLength / beatLengthBase; }
+	public double getTimingPointMultiplier() { return beatLength / beatLengthBase; }
 
 	/**
 	 * Sets a replay to view, or resets the replay if null.


### PR DESCRIPTION
## Overview
After having done roughly 3 months of research, diving into Lazer's C# code (thanks @sr229) and a few tests, playthroughs and watching Auto, I present a PR that would allow Aspire 2017 maps to load and be played without hard-crashing.

However, this is still incomplete:

#### Crashpire (#302)
- [x] Fix `NegativeArraySizeException` when evaluating certain sliders
- [x] Fix `NullPointerException` when a null curve is being loaded to a slider
- [x] Fix `ArrayIndexOutOfBoundsException` when attempting to call `pointAt(float)` where the value of the float is 1 but the `curve` array has a length of 1 (element 0)
- [x]  Parse timings correctly (currently skips nearly 2/3 of the song and note spamming after the 'Skip' portion)
- [x] Compute star rating as per new formula (osu-stable: 6.5 stars, osu-lazer: 130~ stars)

#### Slider issues (#297)
- [x] Fix slider freezing with experimental sliders enabled.
- [x] Fix non-disappearing sliders with experimental sliders disabled.
- [ ] Fix graphical glitching on "repeating" and "double-backing" sliders with experimental sliders disabled.