### PR TITLE
Avoid code duplication in FFmpeg framerate parsing

### DIFF
--- a/src/itdelatrisu/opsu/video/FFmpeg.java
+++ b/src/itdelatrisu/opsu/video/FFmpeg.java
@@ -115,11 +115,10 @@ public class FFmpeg {
 					// Parse framerate
 					// Note: Can contain 'k' suffix (*1000), see dump.c#print_fps.
 					// https://www.ffmpeg.org/doxygen/3.1/dump_8c_source.html#l00119
-					String fps = RegexUtil.findFirst(line, Pattern.compile("\\s(\\d+(\\.\\d+)?k?)\\stbr,"), 1);
-					if (fps.endsWith("k"))
-						framerate = Float.parseFloat(fps.substring(0, fps.length() - 1)) * 1000f;
-					else
-						framerate = Float.parseFloat(fps);
+					String[] fps = RegexUtil.find(line, Pattern.compile("\\s(\\d+(\\.\\d+)?)(k?)\\stbr,"), 1, 3);
+					framerate = Float.parseFloat(fps[0]);
+					if (fps[1] == "k")
+						framerate *= 1000;
 
 					// Parse width/height
 					int[] wh = TextValues.parseInts(RegexUtil.find(line, Pattern.compile("\\s(\\d+)x(\\d+)[\\s,]"), 1, 2));


### PR DESCRIPTION
In case you don't get to it first. (Related: 0b36328, #362)

`(k?)` is used instead of `(k)?` so that the region will always match, even if it's empty.