### PR TITLE
Trim whitespace in skin color parsing

### DIFF
--- a/src/itdelatrisu/opsu/skins/SkinLoader.java
+++ b/src/itdelatrisu/opsu/skins/SkinLoader.java
@@ -176,9 +176,9 @@ public class SkinLoader {
 						try {
 							String[] rgb = tokens[1].split(",");
 							Color color = new Color(
-								Integer.parseInt(rgb[0]),
-								Integer.parseInt(rgb[1]),
-								Integer.parseInt(rgb[2])
+								Integer.parseInt(rgb[0].trim()),
+								Integer.parseInt(rgb[1].trim()),
+								Integer.parseInt(rgb[2].trim())
 							);
 							switch (tokens[0]) {
 							case "Combo1":


### PR DESCRIPTION
Some skins, notably manually edited ones, include spaces in the RGB color values, which causes the integer parse command to fail as it cannot recognize whitespace as a valid number.

This should now be able to read RGB values with spaces, for example: `Combo3 : 255, 121, 198` and treat it the same way as `Combo3: 255,121,198`