### PR TITLE
Add an EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root=true
+
+[*]
+insert_final_newline=true
+trim_trailing_whitespace=true
+charset=utf-8
+
+[*.java]
+indent_style=tab


### PR DESCRIPTION
[EditorConfig](http://editorconfig.org/) allows [supporting editors](http://editorconfig.org/#download) to automatically adjust their settings, most significantly in our case the use of tabs instead of spaces for indentation.

I would have included `end_of_line=lf`, but not all files in the project have LF line endings. The following have CRLF line endings:
```
$ find src -name '*.java' -exec file {} \; | grep CRLF | cut -f 1 -d :
src/itdelatrisu/opsu/audio/MultiClip.java
src/itdelatrisu/opsu/objects/curves/CatmullCurve.java
src/itdelatrisu/opsu/objects/curves/CentripetalCatmullRom.java
src/itdelatrisu/opsu/objects/curves/CurveType.java
src/itdelatrisu/opsu/objects/curves/EqualDistanceMultiCurve.java
src/itdelatrisu/opsu/replay/ReplayImporter.java
src/itdelatrisu/opsu/ui/KineticScrolling.java
src/org/newdawn/slick/Image.java
src/org/newdawn/slick/Music.java
src/org/newdawn/slick/openal/AudioInputStream.java
src/org/newdawn/slick/openal/Mp3InputStream.java
src/org/newdawn/slick/openal/OpenALStreamPlayer.java
src/org/newdawn/slick/openal/SoundStore.java
```