### PR TITLE
Add catch clause for UnsupportedAudioFileException and fix LineUnavailableExceptions 

### DIFF
--- a/src/itdelatrisu/opsu/audio/MultiClip.java
+++ b/src/itdelatrisu/opsu/audio/MultiClip.java
@@ -209,7 +209,7 @@ public class MultiClip {
 			// NOTE: AudioSystem.getClip() doesn't work on some Linux setups.
 			DataLine.Info info = new DataLine.Info(Clip.class, format);
 			c = (Clip) AudioSystem.getLine(info);
-			if (format != null)
+			if (format != null && !c.isOpen())
 				c.open(format, audioData, 0, audioData.length);
 
 			// fix PulseAudio issues (hacky, but can't do an instanceof check)

--- a/src/itdelatrisu/opsu/audio/SoundController.java
+++ b/src/itdelatrisu/opsu/audio/SoundController.java
@@ -40,6 +40,7 @@ import javax.sound.sampled.Clip;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.LineListener;
 import javax.sound.sampled.LineUnavailableException;
+import javax.sound.sampled.UnsupportedAudioFileException;
 
 import org.newdawn.slick.Color;
 import org.newdawn.slick.SlickException;
@@ -97,6 +98,9 @@ public class SoundController {
 
 			AudioInputStream audioIn = AudioSystem.getAudioInputStream(url);
 			return loadClip(ref, audioIn);
+		} catch (UnsupportedAudioFileException e) {
+			ErrorHandler.error(String.format("Invalid data found on audio file '%s'.", ref), e, true);
+			return null;
 		} catch (Exception e) {
 			ErrorHandler.error(String.format("Failed to load audio file '%s'.", ref), e, true);
 			return null;


### PR DESCRIPTION
## Overview
Needs more testing on other setups.
Adds more details with issues regarding sound file loading and possibly fix the Linux side of `LineUnavailableException`s.
Has been tested on Windows (`Windows 10 x64`) and Linux (`Mint Cinnamon 18.3 x64`) with no ill effects.

### Changes: 
- Don't open a line with the same format twice (as found in [this StackOverflow post](https://stackoverflow.com/questions/11915469/java-sound-format-not-supported))

- Add an additional catch clause for `UnsupportedAudioFileException` to better distinguish audio file-specific errors (such as corrupted files) and more general errors (such as non-present decoders for an audio type)