### PR TITLE
Add About entry to copy debug info

### DIFF
--- a/src/itdelatrisu/opsu/states/ButtonMenu.java
+++ b/src/itdelatrisu/opsu/states/ButtonMenu.java
@@ -24,6 +24,7 @@ import itdelatrisu.opsu.GameMod;
 import itdelatrisu.opsu.Opsu;
 import itdelatrisu.opsu.OpsuConstants;
 import itdelatrisu.opsu.ScoreData;
+import itdelatrisu.opsu.Utils;
 import itdelatrisu.opsu.audio.MusicController;
 import itdelatrisu.opsu.audio.SoundController;
 import itdelatrisu.opsu.audio.SoundEffect;
@@ -249,7 +250,7 @@ public class ButtonMenu extends BasicGameState {
 			}
 		},
 		/** The "About" screen. */
-		ABOUT (new Button[] { Button.ABOUT_WEBSITE, Button.ABOUT_REPOSITORY, Button.ABOUT_REPORT, Button.ABOUT_CREDITS, Button.ABOUT_CLOSE }) {
+		ABOUT (new Button[] { Button.ABOUT_WEBSITE, Button.ABOUT_REPOSITORY, Button.ABOUT_REPORT, Button.ABOUT_ENV, Button.ABOUT_CREDITS, Button.ABOUT_CLOSE }) {
 			@Override
 			public String[] getTitle(GameContainer container, StateBasedGame game) {
 				String version = Updater.get().getCurrentVersion();
@@ -608,6 +609,15 @@ public class ButtonMenu extends BasicGameState {
 				} catch (Exception e) {
 					UI.getNotificationManager().sendNotification("The web page could not be opened.", Color.red);
 				}
+				game.enterState(Opsu.STATE_MAINMENU, new EmptyTransition(), new FadeInTransition());
+			}
+		},
+		ABOUT_ENV ("Copy Debug Info", Color.orange) {
+			@Override
+			public void click(GameContainer container, StateBasedGame game) {
+				SoundController.playSound(SoundEffect.MENUHIT);
+				Utils.copyToClipboard(ErrorHandler.getEnvironmentInfoForIssue());
+				UI.getNotificationManager().sendNotification("Debug info copied to clipboard.");
 				game.enterState(Opsu.STATE_MAINMENU, new EmptyTransition(), new FadeInTransition());
 			}
 		},


### PR DESCRIPTION
Adding this gives us a reliable, cross-platform way of getting this info for issues that don't already have it.

I went with the clipboard implementation because it was the simplest to implement and it would be the most likely use case.

Resolves #374  