### PR TITLE
Add minimal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+<!--
+  Issues reported here should be for the desktop version only.
+  For Android, please open an issue in the appropriate repository:
+  - APK: https://github.com/fluddokt/opsu/issues
+  - Play Store: https://github.com/AnirudhRahul/opsu-Android/issues
+-->


### PR DESCRIPTION
This template should redirect reporters to the proper repo for the Android version. The HTML comment will not appear in the actual issue.

From the discussion in #387. It should be the minimal amount of effort needed to get issues where they need to be.