### PR TITLE
fix near-infinite loop on certain 2B maps

### DIFF
--- a/src/itdelatrisu/opsu/states/Game.java
+++ b/src/itdelatrisu/opsu/states/Game.java
@@ -467,7 +467,12 @@ public class Game extends BasicGameState {
 					if (autoPoint == null) {
 						Vec2f endPoint = gameObjects[objectIndex].getPointAt(trackPosition);
 						int totalTime = objectTime - startTime;
-						autoPoint = getPointAt(startPoint.x, startPoint.y, endPoint.x, endPoint.y, (float) (trackPosition - startTime) / totalTime);
+
+						if (totalTime == 0)
+							// this can happen on 2B maps, see issue 401
+							autoPoint = endPoint;
+						else
+							autoPoint = getPointAt(startPoint.x, startPoint.y, endPoint.x, endPoint.y, (float) (trackPosition - startTime) / totalTime);
 
 						// hit circles: show a mouse press
 						int offset300 = hitResultOffset[GameData.HIT_300];


### PR DESCRIPTION
fixes issue #401 (minus the stack leniency calculations) caused by the cursor trail taking a very long time to draw, caused by autopoint being at infinity coordinates, caused by a division by zero caused by one hitobject's start time being the same as the previous hitobject's end time.

I've added an explicit check for `0`. Clamping the  `t` value between `[0, 1]` would've also fixed it, but I don't think that's necessary.