### PR TITLE
Added ability to adjust options sliders with arrow keys

### DIFF
--- a/src/itdelatrisu/opsu/options/OptionsOverlay.java
+++ b/src/itdelatrisu/opsu/options/OptionsOverlay.java
@@ -905,6 +905,15 @@ public class OptionsOverlay extends AbstractComponent {
 			}
 		}
 
+		// increment or decrement slider value with arrow keys
+		if (hoverOption != null && hoverOption.getType() == OptionType.NUMERIC) {
+			if (input.isKeyPressed(Input.KEY_RIGHT))
+				adjustSliderWithKey(Input.KEY_RIGHT);
+			else if (input.isKeyPressed(Input.KEY_LEFT))
+				adjustSliderWithKey(Input.KEY_LEFT);
+		} else
+			input.clearKeyPressedRecord();
+
 		if (!mouseMoved)
 			return;
 
@@ -1342,6 +1351,27 @@ public class OptionsOverlay extends AbstractComponent {
 
 		// set new value
 		updateSliderOption(mouseX, mouseY);
+
+		// play sound effect
+		if (hoverOption.getIntegerValue() != oldSliderValue && sliderSoundDelay == 0) {
+			sliderSoundDelay = SLIDER_SOUND_INTERVAL;
+			SoundController.playSound(SoundEffect.MENUCLICK);
+		}
+	}
+
+	/**
+	 * Increments or decrements slider value if user presses right or left arrow key.
+	 * @param key the pressed key
+	 */
+	private void adjustSliderWithKey(int key) {
+		int oldSliderValue = hoverOption.getIntegerValue();
+
+		// increment or decrement value
+		if (key == Input.KEY_RIGHT) {
+			hoverOption.setValue(hoverOption.getIntegerValue() + 1);
+		} else if (key == Input.KEY_LEFT) {
+			hoverOption.setValue(hoverOption.getIntegerValue() - 1);
+		}
 
 		// play sound effect
 		if (hoverOption.getIntegerValue() != oldSliderValue && sliderSoundDelay == 0) {


### PR DESCRIPTION
You can use arrow keys to make +1 or -1 adjustments to options sliders (offset, volume, etc.)

If there's a better way of doing this I'll give it another go but this is functional at least for the time being.